### PR TITLE
harden GitHub workflows based on zizmor audit

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,20 +1,27 @@
 name: Publish to NuGet
 
 permissions:
+  # Required by actions/checkout to read the repository
   contents: read
-  pull-requests: write
 
 on:
   push:
     tags:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
+    name: Build and publish to NuGet
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      with:
+        persist-credentials: false
 
     - name: Extract version from tag
       run: echo "PACKAGE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,19 +1,26 @@
 name: Generate and Upload SBOM
 
 permissions:
+  # Required by actions/checkout to read the repository
   contents: read
-  pull-requests: write
 
 on:
   push:
     branches: [ "main" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
+    name: Build and upload SBOMs
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      with:
+        persist-credentials: false
 
     - name: Setup .NET
       uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,14 +4,18 @@
 name: .NET Tests
 
 permissions:
+  # Required by actions/checkout to read the repository
   contents: read
-  pull-requests: write
 
 on:
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -26,15 +30,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          persist-credentials: false
       - name: Setup .NET
         uses: actions/setup-dotnet@d4c94342e560b34958eacfc5d055d21461ed1c5d # v5
         with:
           dotnet-version: 10.0.x
       - name: Build
-        run: dotnet build --framework=net${{ matrix.dotnet }}
+        env:
+          DOTNET_VERSION: ${{ matrix.dotnet }}
+        run: dotnet build --framework=net"$DOTNET_VERSION"
       - name: Test
+        env:
+          DOTNET_VERSION: ${{ matrix.dotnet }}
         run: |
-          dotnet test --framework=net${{ matrix.dotnet }} --no-build --verbosity normal --collect:"XPlat Code Coverage"
+          dotnet test --framework=net"$DOTNET_VERSION" --no-build --verbosity normal --collect:"XPlat Code Coverage"
       - name: Upload coverage reports to Codecov
         if: ${{ matrix.dotnet == '10.0' }}
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1


### PR DESCRIPTION
   - Drop unnecessary pull-requests:write permission on all workflows
   - Set persist-credentials:false on actions/checkout to prevent token leakage
   - Route matrix.dotnet through env to avoid template injection in run steps
   - Add concurrency groups (publish: queue; CI/SBOM: cancel-in-progress)
   - Name previously anonymous build jobs for clearer Actions UI