### PR TITLE
audit workflows in CI and deny-by-default at workflow root

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -1,8 +1,6 @@
 name: Publish to NuGet
 
-permissions:
-  # Required by actions/checkout to read the repository
-  contents: read
+permissions: {}
 
 on:
   push:
@@ -23,7 +21,7 @@ jobs:
       id-token: write  # Required for OIDC token exchange with nuget.org Trusted Publishing
 
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,8 +1,6 @@
 name: Generate and Upload SBOM
 
-permissions:
-  # Required by actions/checkout to read the repository
-  contents: read
+permissions: {}
 
 on:
   push:
@@ -16,9 +14,11 @@ jobs:
   build:
     name: Build and upload SBOMs
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required by actions/checkout to read the repository
 
     steps:
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,9 +3,7 @@
 
 name: .NET Tests
 
-permissions:
-  # Required by actions/checkout to read the repository
-  contents: read
+permissions: {}
 
 on:
   push:
@@ -21,6 +19,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required by actions/checkout to read the repository
 
     strategy:
       matrix:
@@ -29,7 +29,7 @@ jobs:
     name: .NET ${{ matrix.dotnet }} Tests
 
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Setup .NET

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: GitHub Actions Security Audit
+
+permissions: {}
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    name: Audit workflows with zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read  # Required by actions/checkout to read the repository
+      security-events: write  # Required to upload SARIF results to GitHub Code Scanning
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+
+    - name: Run zizmor
+      uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
  - Add zizmor workflow (audits on PR/push, uploads SARIF)
  - Tighten existing workflows to permissions:{} at root
  - Move grants to job level so future jobs must opt in